### PR TITLE
Colorise entries based on type

### DIFF
--- a/src/ll.nim
+++ b/src/ll.nim
@@ -163,42 +163,41 @@ proc formatKind(entry: Entry): string =
   if entry.kind == FileType.File:
     return "-"
 
-  "$#".format($entry.kind)[0..0].toLowerAscii
+  result = $entry.kind
+  result = result[0..0].toLowerAscii
 
 
 proc formatPermissions(entry: Entry): string =
   let
     tests = [
-      (perm: FilePermission.fpUserRead, val: "r"),
-      (perm: FilePermission.fpUserWrite, val: "w"),
-      (perm: FilePermission.fpUserExec, val: "x"),
-      (perm: FilePermission.fpGroupRead, val: "r"),
-      (perm: FilePermission.fpGroupWrite, val: "w"),
-      (perm: FilePermission.fpGroupExec, val: "x"),
-      (perm: FilePermission.fpOthersRead, val: "r"),
-      (perm: FilePermission.fpOthersWrite, val: "w"),
-      (perm: FilePermission.fpOthersExec, val: "x"),
+      (perm: FilePermission.fpUserRead, val: 'r'),
+      (perm: FilePermission.fpUserWrite, val: 'w'),
+      (perm: FilePermission.fpUserExec, val: 'x'),
+      (perm: FilePermission.fpGroupRead, val: 'r'),
+      (perm: FilePermission.fpGroupWrite, val: 'w'),
+      (perm: FilePermission.fpGroupExec, val: 'x'),
+      (perm: FilePermission.fpOthersRead, val: 'r'),
+      (perm: FilePermission.fpOthersWrite, val: 'w'),
+      (perm: FilePermission.fpOthersExec, val: 'x'),
     ]
 
   var
-    permissions: seq[string]
+    permissions: array[tests.len, char]
 
-  permissions = @[]
-
-  for test in tests:
+  for i, test in tests:
     if test.perm in entry.permissions:
-      permissions.add(test.val)
+      permissions[i] = test.val
     else:
-      permissions.add("-")
+      permissions[i] = '-'
 
   if isUID(entry.mode):
-    permissions[2] = "S"
+    permissions[2] = 'S'
 
   if isGID(entry.mode):
-    permissions[5] = "S"
+    permissions[5] = 'S'
 
   if FilePermission.fpOthersExec in entry.permissions and hasStickyBit(entry.mode):
-    permissions[8] = "t"
+    permissions[8] = 't'
 
   return permissions.join
 

--- a/tests/all.nim
+++ b/tests/all.nim
@@ -1,1 +1,1 @@
-import paths, listing, sizes
+import paths, listing, sizes, specials

--- a/tests/listing.nim
+++ b/tests/listing.nim
@@ -13,6 +13,8 @@ import unittest
 import tempfile
 import colorize
 
+import util
+
 
 var
   tmpdir: string = nil
@@ -61,14 +63,6 @@ proc getExampleOutput() =
   echo "\nExample output:"
   echo ll(tmpdir)
   echo ""
-
-
-proc clean(s: string): string =
-  s.replace(re"\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]", "")
-
-
-proc isSummaryLine(line: string): bool =
-  return line[0] notin ['l', 'd', '-']
 
 
 suite "basic file listing tests":

--- a/tests/listing.nim
+++ b/tests/listing.nim
@@ -63,6 +63,10 @@ proc getExampleOutput() =
   echo ""
 
 
+proc clean(s: string): string =
+  s.replace(re"\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]", "")
+
+
 proc isSummaryLine(line: string): bool =
   return line[0] notin ['l', 'd', '-']
 
@@ -104,6 +108,8 @@ suite "basic file listing tests":
         parts = line.split(re"\s+")
 
       entries.add(parts[8])
+
+    entries = map(entries, (e) => e.clean)
 
     check entries.len == expected.len
     check entries == expected

--- a/tests/paths.nim
+++ b/tests/paths.nim
@@ -2,6 +2,7 @@
 # anything to be used by other libs/packages
 include ll
 
+import future
 import strutils
 import os
 import unittest
@@ -10,12 +11,17 @@ import unittest
 suite "basic path tests":
 
   test "it provides absolute paths for common shortcuts":
+    let
+      trim = (s: string) => s.strip(leading=false, chars={'/'})
+    
     check:
-      getTargetPath("..") == getCurrentDir() / ".."
-      getTargetPath(".") == getCurrentDir()
-      getTargetPath("~") == getHomeDir()
+      getTargetPath("..").trim == expandFilename(getCurrentDir() / "..").trim
+      getTargetPath(".").trim == getCurrentDir().trim
+      getTargetPath("~").trim == getHomeDir().trim
 
 
   test "it recognises absolute paths":
-    check:
-      getTargetPath("/tmp") == "/tmp"
+    if defined(macosx):
+      check getTargetPath("/tmp") == "/private/tmp"
+    else:
+      check getTargetPath("/tmp") == "/tmp"

--- a/tests/specials.nim
+++ b/tests/specials.nim
@@ -1,0 +1,74 @@
+# source is included since we're not exporting
+# anything to be used by other libs/packages
+include ll
+
+import future
+import unittest
+
+import tempfile
+import colorize
+
+import util
+
+
+var
+  tmpdir: string = nil
+
+
+proc setUpSetUIDListing() =
+  tmpdir = mkdtemp()
+  if tmpdir != nil:
+    echo "  [su] Created tmpdir: $#".format(tmpdir).fg_dark_gray()
+
+  for i in 1..3:
+    writeFile(tmpdir / $i, $i)
+    discard execShellCmd("chmod u+s $#".format(tmpdir / $i))
+
+
+proc setUpSetGIDListing() =
+  tmpdir = mkdtemp()
+  if tmpdir != nil:
+    echo "  [su] Created tmpdir: $#".format(tmpdir).fg_dark_gray()
+
+  for i in 1..3:
+    writeFile(tmpdir / $i, $i)
+    discard execShellCmd("chmod g+s $#".format(tmpdir / $i))
+
+
+proc tearDownSuite() =
+  if tmpdir != nil:
+    removeDir(tmpdir)
+    if not existsDir(tmpdir):
+      echo "  [td] Removed tmpdir: $#".format(
+        tmpdir,
+      ).fg_dark_gray()
+
+
+proc getExampleOutput() =
+  echo "\nExample output:"
+  echo ll(tmpdir)
+  echo ""
+
+
+suite "setuid file listing tests":
+
+  setUpSetUIDListing()
+  
+  test "it identifies the setuid bit":
+    var
+      lines = ll(tmpdir).splitLines()
+      entries: seq[string]
+
+    lines = filter(lines, (l) => not l.isSummaryLine)
+
+    entries = @[]
+    
+    for line in lines:
+      entries.add(line)
+      check "S" in line
+
+    check entries.len == 3
+
+  getExampleOutput()
+  
+  tearDownSuite()

--- a/tests/util.nim
+++ b/tests/util.nim
@@ -1,0 +1,9 @@
+import re
+
+
+proc clean*(s: string): string =
+  s.replace(re"\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]", "")
+
+
+proc isSummaryLine*(line: string): bool =
+  return line[0] notin ['l', 'd', '-']


### PR DESCRIPTION
- add colors for dirs, symlinks, executables
- change the way the arrow is added for symlinks
- fix test to account for colors
- resolves #2