### PR TITLE
Fix bug on an empty directory

### DIFF
--- a/src/ll.nim
+++ b/src/ll.nim
@@ -449,7 +449,8 @@ proc formatSummary(entries: seq[Entry]): string =
 
 
 proc getWidth(items: seq[ColArray], offset = 0): int =
-  max(map(items, (i) => i[offset].clean.len))
+  return if items.len > 0: max(map(items, (i) => i[offset].clean.len))
+         else: 0
 
 
 proc getWidths(items: seq[ColArray]): seq[int] =


### PR DESCRIPTION
ll raises an error on an empty directory as follow.

```
$ mkdir empty
$ ll empty
ll.nim(607)              ll
ll.nim(570)              ll
ll.nim(464)              tabulate
ll.nim(458)              getWidths
ll.nim(452)              getWidth
system.nim(2833)         sysFatal
Error: unhandled exception: index out of bounds [IndexError]
```

This is because the max procedure refers to index-0.
https://github.com/nim-lang/Nim/blob/master/lib/system.nim#L2142

I fixed the getWidth procedure to avoid this error.