### PR TITLE
Fix usage of nil strings

### DIFF
--- a/ll.nimble
+++ b/ll.nimble
@@ -5,14 +5,13 @@ author        = "Phillip Oldham"
 description   = "ll - a more informative ls, based on k"
 license       = "MIT"
 srcDir        = "src"
-skipDirs      = @["tests"]
-skipFiles     = @["colors.nim"]
+skipFiles     = @["usage.txt"]
 bin           = @["ll"]
 
 # Dependencies
 
 requires "nim >= 0.19.0"
-requires "docopt >= 0.6.5"
+requires "docopt >= 0.6.8"
 requires "tempfile >= 0.1.5"
 requires "memo >= 0.2.1"
 
@@ -22,7 +21,6 @@ task debug, "Build with debug enabled":
   --linedir: on
   --stacktrace: on
   --linetrace: on
-  --nilseqs: on
   --debuginfo
   --path:"src"
   --verbose
@@ -33,7 +31,6 @@ task test, "Runs the test suite":
   --linedir: on
   --stacktrace: on
   --linetrace: on
-  --nilseqs: on
   --debuginfo
   --path:"src"
   --verbose
@@ -46,7 +43,6 @@ task profile, "Build with the profiler enabled":
   --profiler:on
   --stacktrace: on
   --linetrace: on
-  --nilseqs: on
   --debuginfo
   --path:"src"
   --verbose

--- a/src/ll.nim
+++ b/src/ll.nim
@@ -448,10 +448,10 @@ proc formatName(entry: Entry): string =
   if entry.kind == FileType.Socket:
     return entry.name.colSocket
 
-  if entry.symlink != nil and existsDir(entry.symlink):
+  if entry.symlink.len != 0 and existsDir(entry.symlink):
     return entry.name.colDirectory
 
-  if entry.symlink != nil:
+  if entry.symlink.len != 0:
     return entry.name.colSymlink
 
   if entry.executable:
@@ -461,7 +461,7 @@ proc formatName(entry: Entry): string =
 
 
 proc formatArrow(entry: Entry): string =
-  if entry.symlink == nil:
+  if entry.symlink.len == 0:
     return ""
 
   if entry.symlinkBroken:
@@ -471,7 +471,7 @@ proc formatArrow(entry: Entry): string =
 
 
 proc formatSymlink(entry: Entry): string =
-  if entry.symlink == nil:
+  if entry.symlink.len == 0:
     return ""
 
   if entry.symlinkBroken:
@@ -659,14 +659,14 @@ when isMainModule:
   let args = docopt(Usage, version=AppVersionFull)
 
   var
-    target_path =
+    targetPath =
       if not args["<path>"]: ""
       else: $args["<path>"]
 
-  target_path = getTargetPath(target_path)
+  targetPath = getTargetPath(targetPath)
 
   echo ll(
-    path=target_path,
+    path=targetPath,
     all=args["--all"],
     aall=args["--almost-all"],
     dirsOnly=args["--directory"],

--- a/src/llpkg/display.nim
+++ b/src/llpkg/display.nim
@@ -53,9 +53,9 @@ const
 
 
 let
-  ColorCode = re"\x1B\[([0-9]{1,2}(;[0-9]+)*)?[mGK]"
+  colorCode = re"\x1B\[([0-9]{1,2}(;[0-9]+)*)?[mGK]"
 
-  
+
 proc reset(): string {.procvar.} =
   "\e[0m"
 
@@ -113,14 +113,14 @@ proc colorizeBrokenSymlink*(s: string): string {.procvar.} =
 
 
 proc clean*(s: string): string =
-  s.replace(ColorCode, "")
+  s.replace(colorCode, "")
 
 
 proc padLeft*(s: string, l=0, c=' '): string =
   ## add `l` instances of `c`
   ## to the left side of string `s`
   let
-    markers = s.findAll(ColorCode)
+    markers = s.findAll(colorCode)
   join([markers[0], align(s.clean(), l, c), markers[1]])
 
 
@@ -128,7 +128,7 @@ proc padRight*(s: string, l=0, c=' '): string =
   ## add `l` instances of `c`
   ## to the right side of string `s`
   let
-    markers = s.findAll(ColorCode)
+    markers = s.findAll(colorCode)
   join([markers[0], alignLeft(s.clean(), l, c), markers[1]])
 
 

--- a/tests/listing_tests.nim
+++ b/tests/listing_tests.nim
@@ -16,13 +16,13 @@ import util
 
 
 var
-  tmpdir: string = nil
+  tmpdir: string
 
 
 
 proc setUpBasicListing() =
   tmpdir = mkdtemp()
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     echo "  [su] Created tmpdir: $#".format(tmpdir).fgDarkGray()
 
   for i in 1..9:
@@ -32,7 +32,7 @@ proc setUpBasicListing() =
 
 proc setUpDirectoryListing() =
   tmpdir = mkdtemp()
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     echo "  [su] Created tmpdir: $#".format(tmpdir).fgDarkGray()
 
   for i in 1..9:
@@ -41,7 +41,7 @@ proc setUpDirectoryListing() =
 
 proc setUpMixedListing() =
   tmpdir = mkdtemp()
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     echo "  [su] Created tmpdir: $#".format(tmpdir).fgDarkGray()
 
   for i in 1..4:
@@ -50,10 +50,10 @@ proc setUpMixedListing() =
   for i in 5..9:
     writeFile(tmpdir / $i, $i)
 
-    
+
 proc setUpSymlinkListing() =
   tmpdir = mkdtemp()
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     echo "  [su] Created tmpdir: $#".format(tmpdir).fgDarkGray()
 
   for i in 1..4:
@@ -67,7 +67,7 @@ proc setUpSymlinkListing() =
 
 proc setUpSizedListing() =
   tmpdir = mkdtemp()
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     echo "  [su] Created tmpdir: $#".format(tmpdir).fgDarkGray()
 
   for i in 1..9:
@@ -75,7 +75,7 @@ proc setUpSizedListing() =
 
 
 proc tearDownSuite() =
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     removeDir(tmpdir)
     if not existsDir(tmpdir):
       echo "  [td] Removed tmpdir: $#".format(
@@ -98,7 +98,7 @@ proc getExampleOutput(sortReverse=false, sortBySize=false, sortByMtime=false, di
 suite "basic file listing tests":
 
   setUpBasicListing()
-  
+
   test "it returns the correct number of entries":
     var
       lines = ll(tmpdir).splitLines()
@@ -106,8 +106,6 @@ suite "basic file listing tests":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       entries.add(line)
 
@@ -120,9 +118,6 @@ suite "basic file listing tests":
       lines = ll(tmpdir).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
-
-    entries = @[]
-    expected = @[]
 
     for i in 1..9:
       expected.add($i)
@@ -139,27 +134,27 @@ suite "basic file listing tests":
   test "it contains permissions":
     var
       lines = ll(tmpdir).splitLines()
-    
+
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
     for line in lines:
       var permissions = line.split[0]
       permissions = permissions[1..^1]
-      
+
       check permissions.len == 9
-      
+
       for permission in permissions:
         check permission in ['r', 'w', 'x', '-']
 
   test "it contains owner details":
     var
       lines = ll(tmpdir).splitLines()
-    
+
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
     let
       reUnixName = re"\b[a-zA-Z]+[a-zA-Z_0-9]*\b"
- 
+
     for line in lines:
       var
         parts = line.split(re"\s+")
@@ -173,14 +168,14 @@ suite "basic file listing tests":
   test "it contains a modified datetime":
     var
       lines = ll(tmpdir).splitLines()
-    
+
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
     let
       reDay = re"\b\d\d?\b"
       reMonth = re"[JFMASOND][a-z]{2}"
       reTime = re"[0-2]\d:[0-5]\d"
- 
+
     for line in lines:
       var
         parts = line.split(re"\s+")[5..7]
@@ -200,7 +195,7 @@ suite "basic file listing tests":
 
 
 suite "directory listing tests":
-  
+
   setUpDirectoryListing()
 
   test "it returns the correct number of entries":
@@ -210,8 +205,6 @@ suite "directory listing tests":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       entries.add(line)
 
@@ -225,13 +218,13 @@ suite "directory listing tests":
 
     for line in lines:
       check line[0] == 'd'
-    
+
   getExampleOutput()
   tearDownSuite()
 
 
 suite "symlink listing tests":
-  
+
   setUpSymlinkListing()
 
   test "it returns the correct number of entries":
@@ -241,8 +234,6 @@ suite "symlink listing tests":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       entries.add(line)
 
@@ -255,14 +246,12 @@ suite "symlink listing tests":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       if line[0] == 'l':
          entries.add(line)
 
     check entries.len == 4
-    
+
   test "it displays symlinks":
     var
       lines = ll(tmpdir).splitLines()
@@ -270,14 +259,12 @@ suite "symlink listing tests":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       if ">" in line:
          entries.add(line)
 
     check entries.len == 4
-    
+
   test "it displays broken symlinks":
     var
       lines = ll(tmpdir).splitLines()
@@ -285,14 +272,12 @@ suite "symlink listing tests":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       if "~>" in line:
          entries.add(line)
 
     check entries.len == 1
-    
+
   getExampleOutput()
   tearDownSuite()
 
@@ -375,7 +360,7 @@ suite "formatting tests":
 
 
 suite "sorting option tests: reverse":
-      
+
   setUpBasicListing()
 
   test "it reverses ordering for -r flag":
@@ -385,9 +370,6 @@ suite "sorting option tests: reverse":
       lines = ll(tmpdir, sortReverse=true).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
-
-    entries = @[]
-    expected = @[]
 
     for i in 1..9:
       expected.add($i)
@@ -403,12 +385,12 @@ suite "sorting option tests: reverse":
     check entries.len == expected.len
     check entries == expected
 
-  getExampleOutput(sortReverse=true)  
+  getExampleOutput(sortReverse=true)
   tearDownSuite()
 
 
 suite "sorting option tests: size":
-      
+
   setUpSizedListing()
 
   test "it sorts by size order, descending":
@@ -418,9 +400,6 @@ suite "sorting option tests: size":
       lines = ll(tmpdir, sortBySize=true).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
-
-    entries = @[]
-    expected = @[]
 
     for i in 1..9:
       expected.add($i)
@@ -444,9 +423,6 @@ suite "sorting option tests: size":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    expected = @[]
-
     for i in 1..9:
       expected.add($i)
 
@@ -462,9 +438,9 @@ suite "sorting option tests: size":
   getExampleOutput(sortBySize=true)
   tearDownSuite()
 
-  
+
 suite "sorting option tests: modified time":
-      
+
   setUpBasicListing()
 
   test "it sorts by time order":
@@ -474,9 +450,6 @@ suite "sorting option tests: modified time":
       lines = ll(tmpdir, sortByMtime=true).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
-
-    entries = @[]
-    expected = @[]
 
     for i in 1..9:
       expected.add($i)
@@ -499,9 +472,6 @@ suite "sorting option tests: modified time":
       lines = ll(tmpdir, sortByMtime=true, sortReverse=true).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
-
-    entries = @[]
-    expected = @[]
 
     for i in 1..9:
       expected.add($i)
@@ -530,8 +500,6 @@ suite "filter option tests: directories":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       entries.add(line)
 
@@ -544,8 +512,6 @@ suite "filter option tests: directories":
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
-    entries = @[]
-    
     for line in lines:
       entries.add(line)
 

--- a/tests/specials_tests.nim
+++ b/tests/specials_tests.nim
@@ -11,12 +11,12 @@ import util
 
 
 var
-  tmpdir: string = nil
+  tmpdir: string
 
 
 proc setUpSetUIDListing() =
   tmpdir = mkdtemp()
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     echo "  [su] Created tmpdir: $#".format(tmpdir).fgDarkGray()
 
   for i in 1..3:
@@ -26,7 +26,7 @@ proc setUpSetUIDListing() =
 
 proc setUpSetGIDListing() =
   tmpdir = mkdtemp()
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     echo "  [su] Created tmpdir: $#".format(tmpdir).fgDarkGray()
 
   for i in 1..3:
@@ -35,7 +35,7 @@ proc setUpSetGIDListing() =
 
 
 proc tearDownSuite() =
-  if tmpdir != nil:
+  if tmpdir.len != 0:
     removeDir(tmpdir)
     if not existsDir(tmpdir):
       echo "  [td] Removed tmpdir: $#".format(
@@ -52,7 +52,7 @@ proc getExampleOutput() =
 suite "setuid file listing tests":
 
   setUpSetUIDListing()
-  
+
   test "it identifies the setuid bit":
     var
       lines = ll(tmpdir).splitLines()
@@ -60,8 +60,6 @@ suite "setuid file listing tests":
 
     lines = filter(lines, (l) => not l.isSummaryLine)
 
-    entries = @[]
-    
     for line in lines:
       entries.add(line)
       check "S" in line
@@ -69,5 +67,5 @@ suite "setuid file listing tests":
     check entries.len == 3
 
   getExampleOutput()
-  
+
   tearDownSuite()


### PR DESCRIPTION
Removes usage of nil strings. Removes redundant seqs initializations. Bump required `docopt` version for `nil` fixes.
All tests pass locally.