### PR TITLE
Accept and list multiple paths

### DIFF
--- a/ll.nimble
+++ b/ll.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.0"
+version       = "0.3.0"
 author        = "Phillip Oldham"
 description   = "ll - a more informative ls, based on k"
 license       = "MIT"

--- a/tests/listing_tests.nim
+++ b/tests/listing_tests.nim
@@ -84,9 +84,9 @@ proc tearDownSuite() =
 
 
 proc getExampleOutput(sortReverse=false, sortBySize=false, sortByMtime=false, dirsOnly=false) =
-  echo "\nExample output:"
+  echo "\nExample output for $#".format(tmpdir)
   echo llCompose(
-    tmpdir,
+    @[tmpdir],
     buildDisplayOpts(
       sortReverse=sortReverse,
       sortBySize=sortBySize,
@@ -103,7 +103,7 @@ suite "basic file listing tests":
 
   test "it returns the correct number of entries":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
@@ -117,7 +117,7 @@ suite "basic file listing tests":
     var
       entries: seq[string]
       expected: seq[string]
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -135,7 +135,7 @@ suite "basic file listing tests":
 
   test "it contains permissions":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -150,7 +150,7 @@ suite "basic file listing tests":
 
   test "it contains owner details":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -169,7 +169,7 @@ suite "basic file listing tests":
 
   test "it contains a modified datetime":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -202,7 +202,7 @@ suite "directory listing tests":
 
   test "it returns the correct number of entries":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
@@ -214,7 +214,7 @@ suite "directory listing tests":
 
   test "it identifies directories":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -231,7 +231,7 @@ suite "symlink listing tests":
 
   test "it returns the correct number of entries":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
@@ -243,7 +243,7 @@ suite "symlink listing tests":
 
   test "it identifies symlinks":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
@@ -256,7 +256,7 @@ suite "symlink listing tests":
 
   test "it displays symlinks":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
@@ -269,7 +269,7 @@ suite "symlink listing tests":
 
   test "it displays broken symlinks":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
@@ -369,7 +369,7 @@ suite "sorting option tests: reverse":
     var
       entries: seq[string]
       expected: seq[string]
-      lines = llCompose(tmpdir, buildDisplayOpts(sortReverse=true)).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts(sortReverse=true)).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -399,7 +399,7 @@ suite "sorting option tests: size":
     var
       entries: seq[string]
       expected: seq[string]
-      lines = llCompose(tmpdir, buildDisplayOpts(sortBySize=true)).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts(sortBySize=true)).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -421,7 +421,7 @@ suite "sorting option tests: size":
     var
       entries: seq[string]
       expected: seq[string]
-      lines = llCompose(tmpdir, buildDisplayOpts(sortBySize=true, sortReverse=true)).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts(sortBySize=true, sortReverse=true)).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -449,7 +449,7 @@ suite "sorting option tests: modified time":
     var
       entries: seq[string]
       expected: seq[string]
-      lines = llCompose(tmpdir, buildDisplayOpts(sortByMtime=true)).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts(sortByMtime=true)).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -471,7 +471,7 @@ suite "sorting option tests: modified time":
     var
       entries: seq[string]
       expected: seq[string]
-      lines = llCompose(tmpdir, buildDisplayOpts(sortByMtime=true, sortReverse=true)).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts(sortByMtime=true, sortReverse=true)).splitLines()
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
 
@@ -497,7 +497,7 @@ suite "filter option tests: directories":
 
   test "it shows only directories":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts(dirsOnly=true)).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts(dirsOnly=true)).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)
@@ -509,7 +509,7 @@ suite "filter option tests: directories":
 
   test "it shows only files":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts(filesOnly=true)).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts(filesOnly=true)).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine).map(clean)

--- a/tests/path_tests.nim
+++ b/tests/path_tests.nim
@@ -15,13 +15,13 @@ suite "basic path tests":
       trim = (s: string) => s.strip(leading=false, chars={'/'})
 
     check:
-      getTargetPath(@[".."]).trim == expandFilename(getCurrentDir() / "..").trim
-      getTargetPath(@["."]).trim == getCurrentDir().trim
-      getTargetPath(@["~"]).trim == getHomeDir().trim
+      getTargetPath("..").trim == expandFilename(getCurrentDir() / "..").trim
+      getTargetPath(".").trim == getCurrentDir().trim
+      getTargetPath("~").trim == getHomeDir().trim
 
 
   test "it recognises absolute paths":
     if defined(macosx):
-      check getTargetPath(@["/tmp"]) == "/private/tmp"
+      check getTargetPath("/tmp") == "/private/tmp"
     else:
-      check getTargetPath(@["/tmp"]) == "/tmp"
+      check getTargetPath("/tmp") == "/tmp"

--- a/tests/specials_tests.nim
+++ b/tests/specials_tests.nim
@@ -45,7 +45,7 @@ proc tearDownSuite() =
 
 proc getExampleOutput() =
   echo "\nExample output:"
-  echo llCompose(tmpdir, buildDisplayOpts())
+  echo llCompose(@[tmpdir], buildDisplayOpts())
   echo ""
 
 
@@ -55,7 +55,7 @@ suite "setuid file listing tests":
 
   test "it identifies the setuid bit":
     var
-      lines = llCompose(tmpdir, buildDisplayOpts()).splitLines()
+      lines = llCompose(@[tmpdir], buildDisplayOpts()).splitLines()
       entries: seq[string]
 
     lines = filter(lines, (l) => not l.isSummaryLine)


### PR DESCRIPTION
This PR allows a `ll` to accept multiple path arguments, and reports on each of them, the same way that `ls` does.